### PR TITLE
bugfix: 简介过长 & 按钮国际化名称不正确 #42

### DIFF
--- a/src/frontend/src/Atom.vue
+++ b/src/frontend/src/Atom.vue
@@ -42,7 +42,6 @@
                 </template>
             </bk-tab>
         </div>
-        <bk-button @click="handleToggleLang">国际化</bk-button>
     </section>
 </template>
 


### PR DESCRIPTION
bugfix: 简介过长 & 按钮国际化名称不正确 #42