### PR TITLE
Potential fix for code scanning alert no. 3: Missing origin verification in `postMessage` handler

### DIFF
--- a/src/frontend/src/data/PublicAtom.vue
+++ b/src/frontend/src/data/PublicAtom.vue
@@ -58,8 +58,12 @@
             ])
         },
         created () {
+            const trustedOrigins = ['https://www.example.com']; // Add trusted origins here
             window.addEventListener('message', (e) => {
-                // if (location.href.indexOf(e.origin) === 0) return
+                if (!trustedOrigins.includes(e.origin)) {
+                    console.warn(`Untrusted origin: ${e.origin}`);
+                    return;
+                }
                 if (e.data && e.data.atomPropsValue && e.data.atomPropsModel) {
                     // 把用户的值和默认值合起来
                     const atomPropsValue = this.getAtomValue(e.data.atomPropsValue, e.data.atomPropsModel)


### PR DESCRIPTION
Potential fix for [https://github.com/TencentBlueKing/ci-CodeCCCheckAtom/security/code-scanning/3](https://github.com/TencentBlueKing/ci-CodeCCCheckAtom/security/code-scanning/3)

To fix the issue, we need to add an origin check in the `postMessage` handler. This involves comparing the `e.origin` property of the event object with a predefined list of trusted origins. If the origin matches one of the trusted origins, the message is processed; otherwise, it is ignored. This ensures that only messages from trusted sources are handled.

Steps to implement the fix:
1. Define a list of trusted origins (e.g., `const trustedOrigins = ['https://www.example.com'];`).
2. Modify the `postMessage` handler to check if `e.origin` is in the list of trusted origins.
3. Process the message only if the origin is trusted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
